### PR TITLE
Image reszie Funktion angepasst

### DIFF
--- a/cloudFunction/requirements.txt
+++ b/cloudFunction/requirements.txt
@@ -1,6 +1,5 @@
 # Function dependencies, for example:
 # package>=version
 google>=3.0.0
-requests>=2.25.1
 google-cloud-storage>=1.36.0
 Pillow>=8.1.0


### PR DESCRIPTION
Die Funktion wird jetzt von einem `PubSub` Event getriggert. Das Event wird von der Firestore API bei einem Aufruf der entsprechenden image upload Pfade ausgelöst. Das verhindert unnötige Aufrufe der Funktion und spart damit Kosten.

Außerdem behalten die Bilder beim resize jetzt ihr Seitenverhältnis.